### PR TITLE
Fix type of a constant value

### DIFF
--- a/scala/dA.scala
+++ b/scala/dA.scala
@@ -19,7 +19,7 @@ class dA(val N: Int, val n_visible: Int, val n_hidden: Int,
     var i: Int = 0
     var j: Int = 0
 
-    val a: Double = 1 / n_visible
+    val a: Double = 1.0 / n_visible
     for(i <- 0 until n_hidden)
       for(j <- 0 until n_visible)
         W(i)(j) = uniform(-a, a)


### PR DESCRIPTION
The type of "val a" in dA.scala is Double.
However, the type of "1 / n_visible" is Int.
Undesirable Implicit type conversion may occur as following example.

```
scala> val a : Double = 1 / 2
a: Double = 0.0
```
