### PR TITLE
Enhance MLP to support multi-hidden-layers in an easy way

### DIFF
--- a/python/MLP.py
+++ b/python/MLP.py
@@ -11,7 +11,6 @@ class MLP(object):
     def __init__(self, input, label, n_in, n_hidden, n_out, rng=None):
         """
         n_hidden: python list represent the hidden dimention 
-        activation: activation function
         """
 
         self.x = input


### PR DESCRIPTION
### Multi-hidden-layers MLP

The original MLP only has one-hidden-layer.  I just Modify it to support a multi-hidden-layer in an easy way. You just need to tell MLP the hidden size in a python list. It is very convenient to experiment in multi-layers.

In the end of the file, I made a MLP with three-hidden-layers, and the test passed.
```python
[[  5.17868684e-05   9.99948213e-01]
 [  9.99878554e-01   1.21445770e-04]
 [  9.99889287e-01   1.10712980e-04]
 [  1.34578242e-04   9.99865422e-01]]
```
Also, I don't know whether the owner still watch this project, but I am great interested in making the project better by implementing some other features, such as CNN,RNN, Momentum/Sgd_momentum/Adam/RmsProp etc. 

Plz Let Me know if you allow me to do this. I'm very glad to hear from you.Thank you. @yusugomori 